### PR TITLE
Minor fix for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ pkg_search_module(PODFMT REQUIRED libpodfmt)
 
 # podorgana example
 add_executable( ${PROJECT_NAME} ${EXAMPLE_SOURCE_FILES} )
-target_compile_options( ${PROJECT_NAME} PUBLIC -g ${CRC_CFLAGS} ${PODFMT_CFLAGS} )
-target_include_directories( ${PROJECT_NAME} PUBLIC ${CRC_INCLUDEDIR} ${PODFMT_INCLUDEDIR} )
-target_link_libraries( ${PROJECT_NAME} PUBLIC ${CRC_LIBRARIES} ${PODFMT_LIBRARIES} )
+target_compile_options( ${PROJECT_NAME} PUBLIC -g ${PODFMT_CFLAGS} ${CRC_CFLAGS} )
+target_include_directories( ${PROJECT_NAME} PUBLIC ${PODFMT_INCLUDEDIR} ${CRC_INCLUDEDIR} )
+target_link_libraries( ${PROJECT_NAME} PUBLIC ${PODFMT_LIBRARIES} ${CRC_LIBRARIES} )
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config)
 


### PR DESCRIPTION
Could not compile on MSYS2 without this, it couldn't read symbols from `libcrc`. Library might be the only one that needs this change, though.